### PR TITLE
Compatability with python>=3.10

### DIFF
--- a/banduppy/unfolding_path.py
+++ b/banduppy/unfolding_path.py
@@ -10,7 +10,10 @@ from  irrep.bandstructure import BandStructure
 if  irrep.__version__ <"1.6.2" :
     raise ImportError("A critical bug was found in irrep-1.6.1, which caused incorrect results for unfolding with spin-orbit. Please ipdate irrep to 1.6.2 or newer (when available)")
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 class Unfolding():
 


### PR DESCRIPTION
Minor change due to removal of Iterable from python>=3.10, see

https://stackoverflow.com/questions/72032032/importerror-cannot-import-name-iterable-from-collections-in-python